### PR TITLE
meson: don't install extra.mo files

### DIFF
--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,3 +1,0 @@
-i18n.gettext('extra',
-    args: '--directory=' + meson.source_root()
-)

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,4 +1,3 @@
 i18n.gettext('io.elementary.calculator',
     args: '--directory=' + meson.source_root()
 )
-subdir('extra')


### PR DESCRIPTION
Those translation files are only used for merging into the .desktop and .appdata.xml files, and not as "real" translations.