### PR TITLE
don't install extra.mo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 ## Building, Testing, and Installation
 
 You'll need the following dependencies:
+
 * libgranite-dev
-* meson
+* meson >= 0.43.0
 * valac
 
 Run `meson build` to configure the build environment. Change to the build directory and run `ninja test` to build and run automated tests

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('io.elementary.calculator', 'vala', 'c')
+project(
+    'io.elementary.calculator', 'vala', 'c',
+    meson_version : '>= 0.43'
+)
 
 i18n = import('i18n')
 

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,3 +1,4 @@
 i18n.gettext('extra',
-    args: '--directory=' + meson.source_root()
+    args: '--directory=' + meson.source_root(),
+    install: false
 )


### PR DESCRIPTION
This uses the new "install" argument to the i18n.gettext() call in meson, which is only present in version 0.43.0 and later.