### PR TITLE
Changed the type of Gtk.MessageType for the infobar to WARNING instead of ERROR

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -124,7 +124,7 @@ namespace PantheonCalculator {
             infobar_label = new Gtk.Label ("");
             infobar.get_content_area ().add (infobar_label);
             infobar.show_close_button = false;
-            infobar.message_type = Gtk.MessageType.ERROR;
+            infobar.message_type = Gtk.MessageType.WARNING;
             infobar.no_show_all = true;
 
             global_grid = new Gtk.Grid ();


### PR DESCRIPTION
This is how it looks now when you mismatch parenthesis or any math error Calculator shows an infobar for:

![The thing in question](https://my.mixtape.moe/ebvlei.png)

Hopefully making the infobar look less like a critical error occurred.