### PR TITLE
Fix source ID

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,40 +1,40 @@
-pantheon-calculator (0.1.4) bionic; urgency=medium
+io.elementary.calculator (0.1.4) bionic; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Tue, 05 Jun 2018 04:32:01 -0500
 
-pantheon-calculator (0.1.3) xenial; urgency=medium
+io.elementary.calculator (0.1.3) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Sun, 13 Aug 2017 18:09:31 -0500
 
-pantheon-calculator (0.1.2) xenial; urgency=medium
+io.elementary.calculator (0.1.2) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Thu, 19 Jan 2017 15:18:31 -0600
 
-pantheon-calculator (0.1.1.1) xenial; urgency=medium
+io.elementary.calculator (0.1.1.1) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Tue, 20 Sep 2016 06:45:21 -0500
 
-pantheon-calculator (0.1.1) xenial; urgency=medium
+io.elementary.calculator (0.1.1) xenial; urgency=medium
 
   * New upstream release.
 
  -- Cody Garver <cody@elementary.io>  Wed, 10 Aug 2016 00:40:48 -0500
 
-pantheon-calculator (0.1.0.1) trusty; urgency=low
+io.elementary.calculator (0.1.0.1) trusty; urgency=low
 
   * Fixed out of range problem (lp:1421608)
 
  -- Cody Garver <cody@elementaryos.org>  Wed, 20 May 2015 00:42:47 -0500
 
-pantheon-calculator (0.1) trusty; urgency=low
+io.elementary.calculator (0.1) trusty; urgency=low
 
   * Initial Release.
 

--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
-Source: pantheon-calculator
+Source: io.elementary.calculator
 Section: x11
-Priority: extra
+Priority: optional
 Maintainer: Cody Garver <cody@elementary.io>
 Build-Depends: appstream,
                debhelper (>= 10.5.1),

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://dep.debian.net/deps/dep5
-Upstream-Name: pantheon-calculator
+Upstream-Name: io.elementary.calculator
 Source: https://github.com/elementary/calculator
 
 Files: *

--- a/debian/rules
+++ b/debian/rules
@@ -12,9 +12,5 @@
 %:
 	dh $@ --buildsystem=meson
 
-override_dh_install:
-	dh_install --fail-missing
-
-override_dh_auto_install:
-	dh_auto_install
-	find . -name "extra.mo" -delete
+override_dh_missing:
+	dh_missing --fail-missing


### PR DESCRIPTION
Changes the source package to io.elementary.calculator. Should fix Houston CI

While we're here:
* Change `extra` to `optional` because of debian warning
* Remove the line to delete extra.mo files because we turned off installing them in Meson