### PR TITLE
Move cursor by Unicode character count, not byte count. (#107)

### DIFF
--- a/data/io.elementary.calculator.appdata.xml.in
+++ b/data/io.elementary.calculator.appdata.xml.in
@@ -11,6 +11,13 @@
     <p>A simple calculator for everyday use. It supports basic and some scientific calculations including trigonometry functions, sin, cos, and tan.</p>
   </description>
   <releases>
+    <release version="Unreleased" date="Future" urgency="medium">
+      <description>
+        <ul>
+          <li>Fix inserting multi-byte characters</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.4" date="2019-11-24" urgency="medium">
       <description>
         <ul>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -291,7 +291,7 @@ namespace PantheonCalculator {
                 new_position -= selection_length;
             }
             entry.insert_at_cursor (label);
-            new_position += label.length;
+            new_position += label.char_count();
             entry.grab_focus ();
             entry.set_position (new_position);
         }
@@ -299,13 +299,13 @@ namespace PantheonCalculator {
         private void function_button_clicked (string label) {
             int selection_start = -1;
             int selection_end = -1;
-            int new_position = entry.get_position ();
             if (entry.get_selection_bounds (out selection_start, out selection_end)) {
+                int new_position = selection_start;
                 string selected_text = entry.get_chars (selection_start, selection_end);
                 string function_call = label + "(" + selected_text + ")";
                 entry.delete_text (selection_start, selection_end);
                 entry.insert_text (function_call, -1, ref selection_start);
-                new_position += function_call.length;
+                new_position += function_call.char_count();
                 entry.grab_focus ();
                 entry.set_position (new_position);
             } else {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -307,7 +307,7 @@ namespace PantheonCalculator {
                 new_position -= selection_length;
             }
             entry.insert_at_cursor (label);
-            new_position += label.char_count();
+            new_position += label.char_count ();
             entry.grab_focus ();
             entry.set_position (new_position);
         }
@@ -321,7 +321,7 @@ namespace PantheonCalculator {
                 string function_call = label + "(" + selected_text + ")";
                 entry.delete_text (selection_start, selection_end);
                 entry.insert_text (function_call, -1, ref selection_start);
-                new_position += function_call.char_count();
+                new_position += function_call.char_count ();
                 entry.grab_focus ();
                 entry.set_position (new_position);
             } else {


### PR DESCRIPTION
Call the char_count() method instead of using the length attribute.