### PR TITLE
Specify gettext domain in AppData

### DIFF
--- a/data/io.elementary.calculator.appdata.xml.in
+++ b/data/io.elementary.calculator.appdata.xml.in
@@ -10,6 +10,7 @@
   <description>
     <p>A simple calculator for everyday use. It supports basic and some scientific calculations including trigonometry functions, sin, cos, and tan.</p>
   </description>
+  <translation type="gettext">io.elementary.calculator</translation>
   <releases>
     <release version="1.5.5" date="2020-04-01" urgency="medium">
       <description>


### PR DESCRIPTION
I believe this is required by appstream-generator to be able to automatically add tags for each language that say how well translated the application is for that language.

I'm just proposing adding this to one repo now to test, but it will likely need adding to all of them and being recommended to AppCenter developers if we want to do https://github.com/elementary/appcenter/issues/440