### PR TITLE
Use add () for normal button without image-button class

### DIFF
--- a/src/Button.vala
+++ b/src/Button.vala
@@ -26,7 +26,7 @@ public class PantheonCalculator.Button : Gtk.Button {
         function = label;
         var lbl = new Gtk.Label (label);
         lbl.use_markup = true;
-        image = lbl;
+        add (lbl);
         tooltip_text = description;
     }
 


### PR DESCRIPTION
Fixes #126 

A simple use of `add ()` instead of making the label as an image(???) of the `Gtk.Button`.