### PR TITLE
MainWindow: Rewrite saved state

### DIFF
--- a/data/io.elementary.calculator.gschema.xml
+++ b/data/io.elementary.calculator.gschema.xml
@@ -16,15 +16,10 @@
             <summary>Saves the decimal places for displayed values.</summary>
             <description>Saves the decimal places for displayed values.</description>
         </key>
-        <key name="window-x" type="i">
-            <default>-100</default>
-            <summary>Window x position.</summary>
-            <description>Saved x position of main calculator window.</description>
-        </key>
-        <key name="window-y" type="i">
-            <default>-100</default>
-            <summary>Window y position.</summary>
-            <description>Saved y position of main calculator window.</description>
+        <key name="window-position" type="(ii)">
+            <default>(-1, -1)</default>
+            <summary>Window position.</summary>
+            <description>Saved position of main calculator window.</description>
         </key>
     </schema>
 </schemalist>

--- a/src/PantheonCalculator.vala
+++ b/src/PantheonCalculator.vala
@@ -39,7 +39,6 @@ namespace PantheonCalculator {
 
             quit_action.activate.connect (() => {
                 if (window != null) {
-                    window.save_state ();
                     window.destroy ();
                 }
             });


### PR DESCRIPTION
Supersedes #127 

* Use one key for window position
* Property bindings so we update settings when events occur

I don't think `remember-app-usage` is the right key for this. I believe that's for the shell to remember when and how much apps have been used. I think `remember-recent-files` is probably closer to what we want here even though it's not strictly correct. Neither of these keys really represent what we're trying to do here though so I'd be fine with either one