### PR TITLE
Change "Add" to "Append" in HistoryDialog

### DIFF
--- a/src/HistoryDialog.vala
+++ b/src/HistoryDialog.vala
@@ -64,7 +64,7 @@ namespace PantheonCalculator {
             };
             scrolled.add (view);
 
-            var add_label = new Gtk.Label (_("Value to add:")) {
+            var add_label = new Gtk.Label (_("Value to append:")) {
                 halign = Gtk.Align.END,
                 hexpand = true
             };
@@ -89,7 +89,7 @@ namespace PantheonCalculator {
 
             add_button (_("Close"), Gtk.ResponseType.CLOSE);
 
-            var button_add = add_button (_("Add"), Gtk.ResponseType.OK);
+            var button_add = add_button (_("Append"), Gtk.ResponseType.OK);
             button_add.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
             show_all ();


### PR DESCRIPTION
For the sake of clarity, the verb `"Add"` here is too confusing, especially in some languages, because you are "adding" a value to the expression, but you could have a subtraction operation, for example.

Someone could argue that in English this isn't a problem and that the string should be localize properly, but there is a collision with the same string in other location with a different meaning:
https://github.com/elementary/calculator/blob/master//src/MainWindow.vala#L128

The label `"Value to add:"` is also modified in order to be consistent

Feel free to suggest other verbs for this context, maybe `"Insert"` is fine as well.