### PR TITLE
CI: use the correct image for the flatpak action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      image: bilelmoussaoui/flatpak-github-actions:elementary-juno
       options: --privileged
 
     steps:


### PR DESCRIPTION
the other image is deprecated and doesn't contain all the necessary tools nowadays.