### PR TITLE
extended-shown unbound from button_extended.active

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
      steps:
        - name: Checkout
-         uses: actions/checkout@v2
+         uses: actions/checkout@v1
        
        - name: Release
          uses: elementary/actions/release@master

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -363,8 +363,7 @@ namespace PantheonCalculator {
             button_e.clicked.connect (() => {regular_button_clicked (button_e.function);});
             button_reciprocal.clicked.connect (() => {button_reciprocal_clicked ();});
 
-
-            button_extended.set_active (settings.get_boolean ("extended-shown"));
+            settings.bind ("extended-shown", button_extended, "active", SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
 
             // The window is constructed before adding to the application.
             // So for the first window, the application will have 0 windows
@@ -607,13 +606,11 @@ namespace PantheonCalculator {
                 button.image = extended_img_2;
                 button.tooltip_text = _("Hide extended functionality");
                 extended_revealer.set_reveal_child (true);
-                settings.set_boolean ("extended-shown", true);
             } else {
                 /* Hide extended functionality */
                 button.image = extended_img_1;
                 button.tooltip_text = _("Show extended functionality");
                 extended_revealer.set_reveal_child (false);
-                settings.set_boolean ("extended-shown", false);
             }
             /* Focusing button_calc because without a new focus it will cause weird window drawing problems. */
             entry.grab_focus ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -363,7 +363,7 @@ namespace PantheonCalculator {
             button_e.clicked.connect (() => {regular_button_clicked (button_e.function);});
             button_reciprocal.clicked.connect (() => {button_reciprocal_clicked ();});
 
-            settings.bind ("extended-shown", button_extended, "active", GLib.SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
+            settings.bind ("extended-shown", button_extended, "active", GLib.SettingsBindFlags.DEFAULT | GLib.SettingsBindFlags.GET_NO_CHANGES);
 
             // The window is constructed before adding to the application.
             // So for the first window, the application will have 0 windows

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -364,7 +364,7 @@ namespace PantheonCalculator {
             button_reciprocal.clicked.connect (() => {button_reciprocal_clicked ();});
 
 
-            settings.bind ("extended-shown", button_extended, "active", GLib.SettingsBindFlags.DEFAULT);
+            button_extended.set_active (settings.get_boolean ("extended-shown"));
 
             // The window is constructed before adding to the application.
             // So for the first window, the application will have 0 windows
@@ -607,11 +607,13 @@ namespace PantheonCalculator {
                 button.image = extended_img_2;
                 button.tooltip_text = _("Hide extended functionality");
                 extended_revealer.set_reveal_child (true);
+                settings.set_boolean ("extended-shown", true);
             } else {
                 /* Hide extended functionality */
                 button.image = extended_img_1;
                 button.tooltip_text = _("Show extended functionality");
                 extended_revealer.set_reveal_child (false);
+                settings.set_boolean ("extended-shown", false);
             }
             /* Focusing button_calc because without a new focus it will cause weird window drawing problems. */
             entry.grab_focus ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -363,7 +363,7 @@ namespace PantheonCalculator {
             button_e.clicked.connect (() => {regular_button_clicked (button_e.function);});
             button_reciprocal.clicked.connect (() => {button_reciprocal_clicked ();});
 
-            settings.bind ("extended-shown", button_extended, "active", SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
+            settings.bind ("extended-shown", button_extended, "active", GLib.SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
 
             // The window is constructed before adding to the application.
             // So for the first window, the application will have 0 windows


### PR DESCRIPTION
This PR is a proposal for a fix of #182 - `extended-shown` settings value is no longer bound to the state but rather loaded on construction of a new window and set when changed. This results in following behaviour
- When user toggles extended functionality on in any open window, `extended-shown` is set to true, however no other instance inherits this action. Newly opened windows of app will have extended functionalities shown as this setting is loaded on construction
- Same applies when user toggles it off in any open window