### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,6 @@ install_data(
 )
 
 i18n.merge_file (
-    'desktop',
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',
     install: true,
@@ -29,7 +28,6 @@ i18n.merge_file (
 )
 
 i18n.merge_file (
-    'appdata',
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
     install: true,


### PR DESCRIPTION
Solves a warning with newer meson:
```
DEPRECATION: i18n.merge_file does not take any positional arguments. This will become a hard error in the next Meson release.
DEPRECATION: i18n.merge_file does not take any positional arguments. This will become a hard error in the next Meson release.
```