### PR TITLE
Hardcode elementary styles, set empty title label

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,14 +40,12 @@ public class PantheonCalculator.Application : Gtk.Application {
             gtk_settings.gtk_theme_name = "io.elementary.stylesheet.blueberry";
         }
 
-        gtk_settings.gtk_application_prefer_dark_theme = (
-            granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
-        );
+        gtk_settings.gtk_application_prefer_dark_theme =
+            granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
 
         granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = (
-                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
-            );
+            gtk_settings.gtk_application_prefer_dark_theme =
+                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
         });
 
         var quit_action = new SimpleAction ("quit", null);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -32,6 +32,24 @@ public class PantheonCalculator.Application : Gtk.Application {
     public override void startup () {
         base.startup ();
 
+        var granite_settings = Granite.Settings.get_default ();
+        var gtk_settings = Gtk.Settings.get_default ();
+        gtk_settings.gtk_icon_theme_name = "elementary";
+
+        if (!gtk_settings.gtk_theme_name.has_prefix ("io.elementary")) {
+            gtk_settings.gtk_theme_name = "io.elementary.stylesheet.blueberry";
+        }
+
+        gtk_settings.gtk_application_prefer_dark_theme = (
+            granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
+        );
+
+        granite_settings.notify["prefers-color-scheme"].connect (() => {
+            gtk_settings.gtk_application_prefer_dark_theme = (
+                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
+            );
+        });
+
         var quit_action = new SimpleAction ("quit", null);
 
         add_action (quit_action);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -98,7 +98,8 @@ public class PantheonCalculator.MainWindow : Gtk.ApplicationWindow {
         button_history.clicked.connect (show_history);
 
         var headerbar = new Gtk.HeaderBar () {
-            show_title_buttons = true
+            show_title_buttons = true,
+            title_widget = new Gtk.Label (null)
         };
         headerbar.pack_end (button_extended);
         headerbar.pack_end (button_history);
@@ -459,19 +460,6 @@ public class PantheonCalculator.MainWindow : Gtk.ApplicationWindow {
 
         child = global_box;
         set_titlebar (headerbar);
-
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        gtk_settings.gtk_application_prefer_dark_theme = (
-            granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
-        );
-
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = (
-                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK
-            );
-        });
 
         entry.grab_focus ();
 


### PR DESCRIPTION
Fixes #236 

![Screenshot from 2023-01-05 12 42 12](https://user-images.githubusercontent.com/7277719/210876543-9863772e-5e47-4d91-aa84-00c807cd6e7d.png)

* Move styles code to application startup so that we don't recreate it for every window
* Hard code elementary stylesheet and icons so that we don't have missing icons or broken styles
* Set the title widget in the headerbar to an empty label so that there isn't a weird empty space with different window button layouts