### PR TITLE
Metainfo: set brand color to Mint 500

### DIFF
--- a/data/calculator.metainfo.xml.in
+++ b/data/calculator.metainfo.xml.in
@@ -22,6 +22,13 @@
     </screenshot>
   </screenshots>
 
+  <branding>
+    <color type="primary">#28bca3</color>
+  </branding>
+  <custom>
+    <value key="x-appcenter-color-primary">#28bca3</value>
+  </custom>
+
   <content_rating type="oars-1.1" />
 
   <provides>


### PR DESCRIPTION
![Screenshot from 2023-05-31 09 54 49](https://github.com/elementary/calculator/assets/7277719/0e1c21ed-6921-472a-9854-0ece8404c88e)

Still setting the custom appcenter key because we're waiting on flatpak actions to support newer appstream