### PR TITLE
Fix crash when pasting into division or multiplication expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .flatpak-builder
+.flatpak
 *~
 ~*
 build

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -532,10 +532,9 @@ public class PantheonCalculator.MainWindow : Gtk.ApplicationWindow {
 
             int start, end;
             entry.get_selection_bounds (out start, out end);
-
-            var before = entry.text.slice (0, start);
-            var after = entry.text.slice (end, entry.text_length);
-
+            // start and end are character positions so cannot use string slice
+            var before = entry.get_chars (0, start);
+            var after = entry.get_chars (end, -1);
             entry.text = before + text + after;
             entry.set_position (before.char_count () + text.char_count ());
         });


### PR DESCRIPTION
Fixes #258 

This fixes incorrect use of string.slice with selection bound positions.  The former takes byte positions whereas the latter gives character positions.  As the division and multiplication characters are multibyte this results in an invalid string.
