### PR TITLE
gschema: remove window position

### DIFF
--- a/data/io.elementary.calculator.gschema.xml
+++ b/data/io.elementary.calculator.gschema.xml
@@ -16,10 +16,5 @@
             <summary>Saves the decimal places for displayed values.</summary>
             <description>Saves the decimal places for displayed values.</description>
         </key>
-        <key name="window-position" type="(ii)">
-            <default>(-1, -1)</default>
-            <summary>Window position.</summary>
-            <description>Saved position of main calculator window.</description>
-        </key>
     </schema>
 </schemalist>


### PR DESCRIPTION
Removed during the GTK 4 port but accidentally leftover in gsettings