### PR TITLE
Evaluate percentage expressions correctly

### DIFF
--- a/src/Core/Evaluation.vala
+++ b/src/Core/Evaluation.vala
@@ -24,7 +24,8 @@ namespace PantheonCalculator.Core {
     private errordomain EVAL_ERROR {
         NO_FUNCTION,
         NO_OPERATOR,
-        NO_CONSTANT
+        NO_CONSTANT,
+        NO_NUMBER
     }
 
     private errordomain SHUNTING_ERROR {
@@ -60,8 +61,7 @@ namespace PantheonCalculator.Core {
             Operator () { symbol = "÷", inputs = 2, prec = 2, fixity = "LEFT", eval = (a, b) => a / b },
             Operator () { symbol = "mod", inputs = 2, prec = 2, fixity = "LEFT", eval = (a, b) => a % b },
             Operator () { symbol = "^", inputs = 2, prec = 3, fixity = "RIGHT", eval = (a, b) => Math.pow (a, b) },
-            Operator () { symbol = "E", inputs = 2, prec = 4, fixity = "RIGHT", eval = (a, b) => a * Math.pow (10, b) },
-            Operator () { symbol = "%", inputs = 1, prec = 5, fixity = "LEFT", eval = (a, b) => b / 100.0 }
+            Operator () { symbol = "E", inputs = 2, prec = 4, fixity = "RIGHT", eval = (a, b) => a * Math.pow (10, b) }
         };
 
         private struct Function { string symbol; int inputs; Eval eval;}
@@ -120,11 +120,15 @@ namespace PantheonCalculator.Core {
             Queue<Token> op_stack = new Queue<Token> ();
 
             foreach (Token t in token_list) {
+            warning ("Shunting found '%s', Type %s", t.content, t.token_type.to_string ());
                 switch (t.token_type) {
                     case TokenType.NUMBER:
                         output.append (t);
                         break;
                     case TokenType.CONSTANT:
+                        output.append (t);
+                        break;
+                    case TokenType.CURRENT_LEFT_VALUE:
                         output.append (t);
                         break;
                     case TokenType.FUNCTION:
@@ -208,6 +212,20 @@ namespace PantheonCalculator.Core {
             foreach (Token t in token_list) {
                 if (t.token_type == TokenType.NUMBER) {
                     stack.push_tail (t);
+                } else if (t.token_type == TokenType.CURRENT_LEFT_VALUE) {
+                    var t1 = stack.pop_tail ();
+                    Token t2;
+                    if (!stack.is_empty () && stack.peek_tail ().token_type == TokenType.NUMBER) {
+                        t2 = stack.peek_tail ().dup ();
+                    } else if (stack.is_empty ()) {
+                        t2 = new Token ("1", TokenType.NUMBER);
+                    } else {
+                        throw new EVAL_ERROR.NO_NUMBER ("");
+                    }
+
+                    stack.push_tail (t2);
+                    stack.push_tail (t1);
+
                 } else if (t.token_type == TokenType.CONSTANT) {
                     try {
                         Constant c = get_constant (t);
@@ -306,6 +324,7 @@ namespace PantheonCalculator.Core {
             if (fabs (d) - 0.0 < double.EPSILON) {
                 d = 0.0;
             }
+
             return new Token (d.to_string (), TokenType.NUMBER);
         }
 

--- a/src/Core/Token.vala
+++ b/src/Core/Token.vala
@@ -24,6 +24,8 @@ namespace PantheonCalculator.Core {
         NUMBER,
         OPERATOR,
         FUNCTION,
+        PERCENT,
+        CURRENT_LEFT_VALUE,
         SEPARATOR,
         CONSTANT,
         P_LEFT,
@@ -41,6 +43,10 @@ namespace PantheonCalculator.Core {
                 content: in_content,
                 token_type: in_token_type
             );
+        }
+
+        public Token dup () {
+            return new Token (content, token_type);
         }
     }
 }


### PR DESCRIPTION
Fixes #222 

 - [x] Evaluate `(a%)` as `(a / 100)` 
 - [x] Evaluate `a + b%` as `a + (b*a/100)`
 - [x] Evaluate `a - b%` as `a - (b*a/100)`
 - [ ] Evaluate `a * b%` as ??   (Google gives `a * (b/100)`)
 - [ ] Evaluate `a / b%` as ??  (Google gives `a / (b/100)`)


To fix this within the current paradigm (reverse Polish notation),  `%` is treated as a special token and a new token representing the current left value (CLV) is introduced.  The former is replaced during scanning with and expression involving `*` `100` and the CLV.  During evaluation the CLV is obtained from the stack.

An advantage of this approach is that it correctly evaluates expressions such as `(100 + 50) + (7 + 3)%` as `165` whereas Google gives the incorrect answer ` 150.1`.

However, it is unclear what the correct answer is for expressions such as ``a * b%`  and `a / b%`.  The current solution gives different answers to Google for these expressions.