### PR TITLE
Insert brackets after function

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -585,9 +585,11 @@ public class PantheonCalculator.MainWindow : Gtk.ApplicationWindow {
         entry.insert_text (function_call, -1, ref selection_start);
         new_position += function_call.char_count ();
         entry.grab_focus ();
-        if (selected_text = "") {
-            entry.set_position (new_position - 1);
+        if (selected_text == "") {
+            new_position--;
         }
+
+        entry.set_position (new_position);
     }
 
     private void button_calc_clicked () {


### PR DESCRIPTION
Fixes #290 

There is no obvious way to unambiguously interpret user input when inserted without brackets and with no selection in the circumstances described in the issue.

The proposed fix is to insert brackets when there is no selection when the function button is pressed in the same way as when there is a selection.  When there is no selection however, the cursor is moved backwards to within the brackets as it is expected that the user will want to insert the parameter.